### PR TITLE
Update .travis.yml: Remove php 5.4, add php 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,15 @@ language: php
 
 php:
   #- 5.3
-  - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 7
     - php: hhvm
 
 env:


### PR DESCRIPTION
This repo already uses the Drupal_TI script, this PR updates the .travis.yml, removing 5.4 and adding php 7.

Shouldn't this repo have 8.x as the main branch? Or is it not that easy to just switch default branches (the github warning hints that there might be problems)?
